### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/genealogy/src/main/java/org/bbekker/genealogy/controller/UploadController.java
+++ b/genealogy/src/main/java/org/bbekker/genealogy/controller/UploadController.java
@@ -61,7 +61,15 @@ public class UploadController {
 
 			// Get the file and save it in a separate upload storage
 			byte[] bytes = file.getBytes();
-			Path path = Paths.get(UPLOAD_FOLDER + file.getOriginalFilename());
+			String filename = file.getOriginalFilename();
+			if (filename.contains("..") || filename.contains("/") || filename.contains("\\")) {
+				throw new IllegalArgumentException("Invalid filename");
+			}
+			Path uploadDir = Paths.get(UPLOAD_FOLDER).normalize().toAbsolutePath();
+			Path path = uploadDir.resolve(filename).normalize().toAbsolutePath();
+			if (!path.startsWith(uploadDir)) {
+				throw new IllegalArgumentException("Invalid filename");
+			}
 			Files.write(path, bytes);
 
 			Future<Boolean> importTask;


### PR DESCRIPTION
Fixes [https://github.com/basbekker/genbekker/security/code-scanning/1](https://github.com/basbekker/genbekker/security/code-scanning/1)

To fix the problem, we need to validate the user-provided filename to ensure it does not contain any path traversal sequences or invalid characters. We can achieve this by checking for the presence of "..", "/", or "\\" in the filename and rejecting it if any are found. Additionally, we should ensure that the resolved path stays within the intended upload directory.

1. Validate the filename to ensure it does not contain any path traversal sequences or invalid characters.
2. Ensure that the resolved path is within the intended upload directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
